### PR TITLE
Add Orbis support

### DIFF
--- a/remote/webby/webby.c
+++ b/remote/webby/webby.c
@@ -15,6 +15,10 @@
 #include "webby_nn_aarch64_socket_bridge.h"
 #endif
 
+#if defined(ORBIS)
+#include "webby_orbis.h"
+#endif
+
 #if defined(__PS3__)
 #include "webby_ps3.h"
 #elif defined(__XBOX__)

--- a/remote/webby/webby_orbis.h
+++ b/remote/webby/webby_orbis.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <errno.h>
+
+#include <net.h>
+#include <libnet/socket.h>
+
+
+typedef int webby_socket_t;
+typedef socklen_t webby_socklen_t;
+
+#define SOMAXCONN 16
+
+#define WB_ALIGN(x) __attribute__((aligned(x)))
+#define WB_INVALID_SOCKET (-1)
+
+static int wb_socket_error(void)
+{
+    return errno;
+}
+
+static int wb_valid_socket(webby_socket_t socket)
+{
+    return socket >= 0;
+}
+
+static void wb_close_socket(webby_socket_t socket)
+{
+    close(socket);
+}
+
+static int wb_is_blocking_error(int error)
+{
+    return EAGAIN == error;
+}
+
+
+static int wb_set_blocking(webby_socket_t socket, int blocking)
+{
+    int ret = -1;
+    if (blocking) {
+        int opt_val = 0; // set non-blocking to false
+        ret = sceNetSetsockopt(socket, SCE_NET_SOL_SOCKET, SCE_NET_SO_NBIO, &opt_val, sizeof(opt_val));
+    } else {
+        int opt_val = 1; // set non-blocking to true
+        ret = sceNetSetsockopt(socket, SCE_NET_SOL_SOCKET, SCE_NET_SO_NBIO, &opt_val, sizeof(opt_val));
+    }
+    //auto err = sce_net_errno;
+    return ret;
+}


### PR DESCRIPTION
Orbis only supports setting socket blocking via their API call. This adds webby_orbis.h, roughly duplicating webby_unix.h but with the appropriate socket blocking call.