### PR TITLE
Cleanup Prospero defines.

### DIFF
--- a/remote/webby/webby.c
+++ b/remote/webby/webby.c
@@ -21,7 +21,7 @@
 #include "webby_xbox.h"
 #elif defined(_WIN32)
 #include "webby_win32.h"
-#elif defined(ORBIS)
+#elif defined(ORBIS) || defined(__PROSPERO__)
 #include "webby_orbis.h"
 #else
 #include "webby_unix.h"


### PR DESCRIPTION
## Description
The PS5 build was relying on the defines: ```ORBIS``` & ```ORBIS_STUB``` which is confusing when trying to debug build issues. This PR changes this to ```__PROSPERO__``` instead.