### PR TITLE
Set timeout to 0 for select call so that we do not yield

### DIFF
--- a/remote/webby/webby.c
+++ b/remote/webby/webby.c
@@ -1349,7 +1349,7 @@ WebbyServerUpdate(struct WebbyServer *srv)
   }
 
   timeout.tv_sec = 0;
-  timeout.tv_usec = 5;
+  timeout.tv_usec = 0;
 
   err = select((int) (max_socket + 1), &read_fds, &write_fds, &except_fds, &timeout);
 


### PR DESCRIPTION
Wait times tend to be a hint at best, and sure enough when using remote imgui I'm seeing (via PIX) main thread idle time on Xbox  significantly greater than the 5 microseconds requested here.  While it's a debug only scenario it's common enough that I think it's worth fixing.  I can't see any reason why a non-blocking call would be a problem?  Certainly remote imgui still works fine with this change, and the stall is gone.